### PR TITLE
コメントアウト: auto_restart.start()

### DIFF
--- a/main.py
+++ b/main.py
@@ -2554,7 +2554,7 @@ async def init_loop():
     await initdatabase()
     await init_voice_list()
     status_update_loop.start()
-    auto_restart.start()
+    # auto_restart.start()
 
     dict_and_cache_loop.start()
     bot.add_view(ActivateButtonView())


### PR DESCRIPTION
auto_restart の開始処理を一時的に無効化しました。必要に応じて再有効化してください。