### PR TITLE
ターゲットホストの判定条件を修正

### DIFF
--- a/main.py
+++ b/main.py
@@ -1491,7 +1491,7 @@ async def text2wav(text, voiceid, is_premium: bool, speed="100", pitch="0", guil
 
 
     if voiceid >= 4000:
-        target_host = f"{aivis_host}"
+        target_host = f"{coeiroink_host}"
     elif voiceid >= 3000:
         target_host = f"{aivoice_host}"
         voiceid -= 3000


### PR DESCRIPTION
voiceid >= 4000 の場合のホストを aivis_host から coeiroink_host に変更。